### PR TITLE
#Refactor

### DIFF
--- a/apis/member-api-server/build.gradle
+++ b/apis/member-api-server/build.gradle
@@ -5,6 +5,4 @@ dependencies {
 
     /* mail */
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-
-    implementation 'org.projectlombok:lombok'
 }

--- a/apis/member-api-server/src/main/java/com/moviemang/member/controller/MemberController.java
+++ b/apis/member-api-server/src/main/java/com/moviemang/member/controller/MemberController.java
@@ -2,22 +2,15 @@ package com.moviemang.member.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.moviemang.coreutils.common.response.CommonResponse;
-import com.moviemang.datastore.dto.MailCertificationDto;
+import com.moviemang.datastore.dto.mail.MailCertificationDto;
 import com.moviemang.datastore.dto.member.MemberJoinDto;
 import com.moviemang.member.domain.DeletedMember;
 import com.moviemang.member.service.MemberService;
 import com.moviemang.security.uitls.AuthenticationUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.validation.Errors;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;

--- a/apis/member-api-server/src/main/java/com/moviemang/member/service/MemberService.java
+++ b/apis/member-api-server/src/main/java/com/moviemang/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.moviemang.member.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.moviemang.coreutils.common.response.CommonResponse;
-import com.moviemang.datastore.dto.MailCertificationDto;
+import com.moviemang.datastore.dto.mail.MailCertificationDto;
 import com.moviemang.datastore.dto.member.MemberJoinDto;
 import com.moviemang.member.domain.DeletedMember;
 

--- a/apis/member-api-server/src/main/java/com/moviemang/member/service/MemberServiceImpl.java
+++ b/apis/member-api-server/src/main/java/com/moviemang/member/service/MemberServiceImpl.java
@@ -6,7 +6,7 @@ import com.moviemang.coreutils.common.exception.BaseException;
 import com.moviemang.coreutils.common.exception.InvalidParamException;
 import com.moviemang.coreutils.common.response.CommonResponse;
 import com.moviemang.coreutils.common.response.ErrorCode;
-import com.moviemang.datastore.dto.MailCertificationDto;
+import com.moviemang.datastore.dto.mail.MailCertificationDto;
 import com.moviemang.datastore.dto.member.MemberJoinDto;
 import com.moviemang.datastore.entity.maria.MailCertification;
 import com.moviemang.datastore.entity.maria.MailServiceUser;

--- a/apis/member-api-server/src/main/resources/application.yml
+++ b/apis/member-api-server/src/main/resources/application.yml
@@ -1,10 +1,20 @@
 spring:
   profiles:
     active: local
-movie:
-  api-key: cbfa45007409cc068286bfeafd12a530
-  base-url: https://api.themoviedb.org/3/
-  img-url: https://image.tmdb.org/t/p/w500
+  mail:
+    host: smtp.gmail.com
+    port: 465
+    username: moviemang2@gmail.com
+    password: jzmljjxrbvvqgqyq
+    default-encoding: UTF-8
+    protocol: smtps
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 ---
 spring:
   config:

--- a/apis/playlist-api-server/src/main/java/com/moviemang/playlist/service/PlaylistServiceImpl.java
+++ b/apis/playlist-api-server/src/main/java/com/moviemang/playlist/service/PlaylistServiceImpl.java
@@ -7,7 +7,7 @@ import com.moviemang.coreutils.common.response.CommonResponse;
 import com.moviemang.coreutils.common.response.ErrorCode;
 import com.moviemang.coreutils.model.vo.HttpClientRequest;
 import com.moviemang.coreutils.utils.httpclient.HttpClient;
-import com.moviemang.datastore.config.MovieApi;
+import com.moviemang.datastore.config.MovieApiConfig;
 import com.moviemang.datastore.domain.PlaylistOrderByLikeDto;
 import com.moviemang.datastore.repository.maria.MemberRepository;
 import com.moviemang.datastore.repository.mongo.like.LikeRepository;
@@ -31,22 +31,22 @@ public class PlaylistServiceImpl implements PlaylistService{
     private LikeRepository likeRepository;
     private MemberRepository memberRepository;
     private ObjectMapper om;
-    private MovieApi movieApi;
+    private MovieApiConfig movieApiConfig;
 
     @Autowired
     public PlaylistServiceImpl(PlaylistRepository playlistRepository, LikeRepository likeRepository, MemberRepository memberRepository,
-                               MovieApi movieApi, ObjectMapper om){
+                               MovieApiConfig movieApiConfig, ObjectMapper om){
         this.playlistRepository = playlistRepository;
         this.likeRepository = likeRepository;
         this.memberRepository = memberRepository;
-        this.movieApi = movieApi;
+        this.movieApiConfig = movieApiConfig;
         this.om = om;
     }
 
     @Override
     public CommonResponse playlistOrderByLike() {
         Map<String, Object> param = new HashMap<>();
-        param.put("api_key", movieApi.getAPI_KEY());
+        param.put("api_key", movieApiConfig.getMovieApiProperties().getApiKey());
         HttpClientRequest request = new HttpClientRequest();
 
         Aggregation likeAggregation = Aggregation.newAggregation(
@@ -61,7 +61,7 @@ public class PlaylistServiceImpl implements PlaylistService{
                     List<String> imgPathList = new ArrayList<>();
                     List<Integer> movieIds = playlistLikeJoin.getMovieIds();
                     for(int movieId : movieIds){
-                        request.setUrl(String.format("%s/movie/%d/images", movieApi.getBASE_URL(), movieId));
+                        request.setUrl(String.format("%s/movie/%d/images", movieApiConfig.getMovieApiProperties().getBaseUrl(), movieId));
                         request.setData(param);
                         try {
                             Map<String, Object> response = om.readValue(HttpClient.get(request), HashMap.class);
@@ -72,7 +72,7 @@ public class PlaylistServiceImpl implements PlaylistService{
                                 continue;
                             }
                             List<Map<String, Object>> posterData = (List<Map<String, Object>>) response.get("posters");
-                            imgPathList.add(movieApi.getIMG_BASE_URL() + posterData.get(0).get("file_path").toString());
+                            imgPathList.add(movieApiConfig.getMovieApiProperties().getImgBaseUrl() + posterData.get(0).get("file_path").toString());
 
                         } catch (Exception e) {
                             log.error("movie not found error => {}", movieId);

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ allprojects {
         /* lombok */
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
+
+        /* Test 코드에서 롬복 사용을 위해서 정의 */
+        testCompileOnly 'org.projectlombok:lombok'
+        testAnnotationProcessor 'org.projectlombok:lombok'
 		
         /* RestDocs */
         testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/core/core-utils/src/main/java/com/moviemang/coreutils/common/response/ErrorCode.java
+++ b/core/core-utils/src/main/java/com/moviemang/coreutils/common/response/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     CERTIFICATION_NOT_EQUAL("인증 번호가 일치하지 않습니다."),
 
     /* 영화 API 관련 Exception */
-    INVALID_API_KEY("API키가 유효하지 않습니다.");
+    INVALID_API_KEY("API키가 유효하지 않습니다."),
+    NOT_FOUND_MOVIE("해당 영화의 데이터가 존재하지 않습니다.");
 
     private final String errorMsg;
 

--- a/core/datastore/build.gradle
+++ b/core/datastore/build.gradle
@@ -5,4 +5,5 @@ dependencies {
         runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
         implementation 'org.springframework.boot:spring-boot-starter-validation'
+        annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/DatastoreApplication.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/DatastoreApplication.java
@@ -2,8 +2,10 @@ package com.moviemang.datastore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan("com.moviemang.datastore.config")
 public class DatastoreApplication {
 
     public static void main(String[] args) {

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/MongoConfig.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/MongoConfig.java
@@ -1,8 +1,9 @@
 package com.moviemang.datastore.config;
 
-import com.mongodb.client.MongoClient;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -10,12 +11,29 @@ import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
-@EnableMongoRepositories(basePackages = "com.moviemang.datastore.repository.mongo", mongoTemplateRef = "mongoTemplate")
+@PropertySource(value = "classpath:${spring.profiles.active}/mongodb.yml", factory = YamlPropertySourceFactory.class)
+@EnableMongoRepositories(basePackages = "com.moviemang.datastore.repository.mongo")
 @EnableMongoAuditing
 public class MongoConfig {
+
     @Bean
-    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
-        MongoDatabaseFactory factory = new SimpleMongoClientDatabaseFactory(mongoClient, "local");
-        return new MongoTemplate(factory);
+    @ConfigurationProperties(prefix = "mongodb")
+    public MongoProperties mongoProperties(){
+        return new MongoProperties();
     }
+
+    @Bean
+    public MongoDatabaseFactory mongoDatabaseFactory() {
+        return new SimpleMongoClientDatabaseFactory(mongoProperties().getConnectionString());
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(mongoDatabaseFactory());
+    }
+
 }
+
+
+
+

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/MongoProperties.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/MongoProperties.java
@@ -1,0 +1,11 @@
+package com.moviemang.datastore.config;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MongoProperties {
+    private String connectionString;
+}

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApi.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApi.java
@@ -1,20 +1,13 @@
 package com.moviemang.datastore.config;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter
 public class MovieApi {
 
     private String API_KEY;
     private String BASE_URL;
     private String IMG_BASE_URL;
-
-    public MovieApi(String api_key, String base_url, String img_base_url) {
-        this.API_KEY = api_key;
-        this.BASE_URL = base_url;
-        this.IMG_BASE_URL = img_base_url;
-    }
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApi.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApi.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 public class MovieApi {
 
-    private String API_KEY;
-    private String BASE_URL;
-    private String IMG_BASE_URL;
+    private String apiKey;
+    private String baseUrl;
+    private String imgBaseUrl;
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApiConfig.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApiConfig.java
@@ -1,15 +1,17 @@
 package com.moviemang.datastore.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
 @Configuration
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
 public class MovieApiConfig {
     @Bean
-    public MovieApi MovieApi(@Value("${movie.api-key}") String API_KEY, @Value("${movie.base-url}") String BASE_URL,
-                             @Value("${movie.img-url}") String IMG_BASE_URL){
-        return new MovieApi(API_KEY, BASE_URL, IMG_BASE_URL);
+    @ConfigurationProperties(prefix = "movie")
+    public MovieApi MovieApi(){
+        return new MovieApi();
     }
 
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApiConfig.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/MovieApiConfig.java
@@ -6,11 +6,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+@PropertySource(value = "classpath:movie/movieApi.yml", factory = YamlPropertySourceFactory.class)
 public class MovieApiConfig {
     @Bean
     @ConfigurationProperties(prefix = "movie")
-    public MovieApi MovieApi(){
+    public MovieApi getMovieApiProperties(){
         return new MovieApi();
     }
 

--- a/core/datastore/src/main/java/com/moviemang/datastore/config/YamlPropertySourceFactory.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/config/YamlPropertySourceFactory.java
@@ -1,0 +1,34 @@
+package com.moviemang.datastore.config;
+
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+import org.springframework.lang.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Properties;
+
+
+public class YamlPropertySourceFactory implements PropertySourceFactory {
+    @Override
+    public PropertySource<?> createPropertySource(@Nullable String name, EncodedResource resource) throws IOException {
+        Properties propertiesFromYaml = loadYamlIntoProperties(resource);
+        String sourceName = name != null ? name : resource.getResource().getFilename();
+        return new PropertiesPropertySource(sourceName, propertiesFromYaml);
+    }
+    private Properties loadYamlIntoProperties(EncodedResource resource) throws FileNotFoundException {
+        try {
+            YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+            factory.setResources(resource.getResource()); factory.afterPropertiesSet();
+            return factory.getObject(); } catch (IllegalStateException e) {
+            // for ignoreResourceNotFound
+            Throwable cause = e.getCause();
+            if (cause instanceof FileNotFoundException) throw (FileNotFoundException) e.getCause();
+            throw e;
+        }
+    }
+
+}

--- a/core/datastore/src/main/java/com/moviemang/datastore/domain/PlaylistLikeJoin.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/domain/PlaylistLikeJoin.java
@@ -1,20 +1,38 @@
 package com.moviemang.datastore.domain;
 
-import com.moviemang.datastore.entity.mongo.Playlist;
-import lombok.*;
+import com.moviemang.datastore.entity.mongo.Like;
+import com.moviemang.datastore.entity.mongo.Tag;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
 
+import javax.persistence.Id;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaylistLikeJoin {
 
-    private List<Playlist> playlist;
-    private int likeCount;
+    @Id
+    private ObjectId _id;
+    private String playlistTitle;
+    private Long memberId;
+    private List<Tag> tags;
+    private List<Integer> movieIds;
+    private boolean display;
+    private List<Like> likes;
 
     @Builder
-    public PlaylistLikeJoin(int likeCount, List<Playlist> playlist) {
-        this.likeCount = likeCount;
-        this.playlist = playlist;
+    public PlaylistLikeJoin(ObjectId _id, String playlistTitle, Long memberId
+            , List<Tag> tags, List<Integer> movieIds, boolean display, List<Like> likes) {
+        this._id = _id;
+        this.playlistTitle = playlistTitle;
+        this.memberId = memberId;
+        this.tags = tags;
+        this.movieIds = movieIds;
+        this.display = display;
+        this.likes = likes;
     }
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/dto/mail/MailCertificationDto.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/dto/mail/MailCertificationDto.java
@@ -1,4 +1,4 @@
-package com.moviemang.datastore.dto;
+package com.moviemang.datastore.dto.mail;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;

--- a/core/datastore/src/main/java/com/moviemang/datastore/entity/maria/MailServiceUser.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/entity/maria/MailServiceUser.java
@@ -16,7 +16,7 @@ public class MailServiceUser extends BaseTimeEntity{
     private Long mailServiceId;
     @Column(name = "member_id")
     private Long memberId;
-    @Column(name = "mebmer_email")
+    @Column(name = "member_email")
     private String memberEmail;
     @Column(name = "content_type")
     private String contentType;

--- a/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/like/CustomizedLikeRepository.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/like/CustomizedLikeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 
 public interface CustomizedLikeRepository {
 
-    AggregationResults<PlaylistLikeJoin> filterByTypeAndGroupByTargetId(Aggregation likeAggregation, String collection);
+    AggregationResults<PlaylistLikeJoin> findTop2ByMemberIdOrderByRegDateDesc(Aggregation likeAggregation, String collection);
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/like/CustomizedLikeRepositoryImpl.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/like/CustomizedLikeRepositoryImpl.java
@@ -14,7 +14,7 @@ public class CustomizedLikeRepositoryImpl implements CustomizedLikeRepository {
     }
 
     @Override
-    public AggregationResults<PlaylistLikeJoin> filterByTypeAndGroupByTargetId(Aggregation likeAggregation, String collection) {
+    public AggregationResults<PlaylistLikeJoin> findTop2ByMemberIdOrderByRegDateDesc(Aggregation likeAggregation, String collection) {
         return mongoTemplate.aggregate(likeAggregation, collection, PlaylistLikeJoin.class);
     }
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/playlist/CustomizedPlaylistRepository.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/playlist/CustomizedPlaylistRepository.java
@@ -1,4 +1,10 @@
 package com.moviemang.datastore.repository.mongo.playlist;
 
+import com.moviemang.datastore.domain.PlaylistLikeJoin;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+
 public interface CustomizedPlaylistRepository {
+
+    AggregationResults<PlaylistLikeJoin> playlistOrderByLike(Aggregation aggregation, String collection);
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/playlist/CustomizedPlaylistRepositoryImpl.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/playlist/CustomizedPlaylistRepositoryImpl.java
@@ -1,6 +1,9 @@
 package com.moviemang.datastore.repository.mongo.playlist;
 
+import com.moviemang.datastore.domain.PlaylistLikeJoin;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 
 public class CustomizedPlaylistRepositoryImpl implements CustomizedPlaylistRepository {
 
@@ -10,4 +13,8 @@ public class CustomizedPlaylistRepositoryImpl implements CustomizedPlaylistRepos
         this.mongoTemplate = mongoTemplate;
     }
 
+    @Override
+    public AggregationResults<PlaylistLikeJoin> playlistOrderByLike(Aggregation aggregation, String collection) {
+        return mongoTemplate.aggregate(aggregation, collection, PlaylistLikeJoin.class);
+    }
 }

--- a/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/playlist/PlaylistRepository.java
+++ b/core/datastore/src/main/java/com/moviemang/datastore/repository/mongo/playlist/PlaylistRepository.java
@@ -5,7 +5,10 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PlaylistRepository extends MongoRepository<Playlist, ObjectId>, CustomizedPlaylistRepository {
 
+    List<Playlist> findTop2ByMemberIdOrderByRegDateDesc(long l);
 }

--- a/core/datastore/src/main/resources/application.yml
+++ b/core/datastore/src/main/resources/application.yml
@@ -15,7 +15,7 @@ management:
   endpoints:
     web:
       cors:
-        allowed-methods: *
+        allowed-methods: '*'
       exposure:
         include: '*'
   health:
@@ -25,6 +25,7 @@ management:
 movie:
   api-key: cbfa45007409cc068286bfeafd12a530
   base-url : https://api.themoviedb.org/3/
-  img-url: https://image.tmdb.org/t/p/w500
+  img-base-url: https://image.tmdb.org/t/p/w500
+
 
 

--- a/core/datastore/src/main/resources/application.yml
+++ b/core/datastore/src/main/resources/application.yml
@@ -1,11 +1,4 @@
 spring:
-  data:
-    mongodb:
-      host: localhost
-      port: 27017
-      database: moviemang
-      username: root
-      password: root-pass
   jpa:
     open-in-view: false
     generate-ddl: true
@@ -28,3 +21,10 @@ management:
   health:
     diskspace:
       enabled: true
+
+movie:
+  api-key: cbfa45007409cc068286bfeafd12a530
+  base-url : https://api.themoviedb.org/3/
+  img-url: https://image.tmdb.org/t/p/w500
+
+

--- a/core/datastore/src/main/resources/dev/mongodb.yml
+++ b/core/datastore/src/main/resources/dev/mongodb.yml
@@ -1,0 +1,3 @@
+// 각 환경에 맞는 url 설정
+mongodb:
+  connectionString: mongodb://localhost:27017/local

--- a/core/datastore/src/main/resources/dev/mongodb.yml
+++ b/core/datastore/src/main/resources/dev/mongodb.yml
@@ -1,3 +1,3 @@
-// 각 환경에 맞는 url 설정
+##각 환경에 맞는 url을 설정해야합니다
 mongodb:
   connectionString: mongodb://localhost:27017/local

--- a/core/datastore/src/main/resources/local/mongodb.yml
+++ b/core/datastore/src/main/resources/local/mongodb.yml
@@ -1,3 +1,3 @@
-  // 각 환경에 맞는 url 설정
+##각 환경에 맞는 url을 설정해야합니다
 mongodb:
   connectionString: mongodb://localhost:27017/local

--- a/core/datastore/src/main/resources/local/mongodb.yml
+++ b/core/datastore/src/main/resources/local/mongodb.yml
@@ -1,0 +1,3 @@
+  // 각 환경에 맞는 url 설정
+mongodb:
+  connectionString: mongodb://localhost:27017/local

--- a/core/datastore/src/main/resources/movie/movieApi.yml
+++ b/core/datastore/src/main/resources/movie/movieApi.yml
@@ -1,0 +1,4 @@
+movie:
+  api-key: cbfa45007409cc068286bfeafd12a530
+  base-url : https://api.themoviedb.org/3/
+  img-base-url: https://image.tmdb.org/t/p/w500

--- a/core/datastore/src/main/resources/prod/mongodb.yml
+++ b/core/datastore/src/main/resources/prod/mongodb.yml
@@ -1,3 +1,3 @@
-  // 각 환경에 맞는 url 설정
+##각 환경에 맞는 url을 설정해야합니다
 mongodb:
   connectionString: mongodb://localhost:27017/local

--- a/core/datastore/src/main/resources/prod/mongodb.yml
+++ b/core/datastore/src/main/resources/prod/mongodb.yml
@@ -1,0 +1,3 @@
+  // 각 환경에 맞는 url 설정
+mongodb:
+  connectionString: mongodb://localhost:27017/local


### PR DESCRIPTION
- 프로파일에 따라 mongodb의 설정이 다르게 적용될 수 있도록 구분
- movie-api 관련 설정 코드 datastore 모듈의 yml파일에 위치시키고 그에 따른 ProperySource 경로 변경
- 이메일 인증번호 전송, 이메일 인증번호 체크 API URL 규격서와 일치화
- MovieApiConfig.java 변수명 변경으로 인한 일부 코드 변경
